### PR TITLE
Fixed issue with latest exports not working correctly

### DIFF
--- a/ExportViewer.Core/Services/DataParsingService.cs
+++ b/ExportViewer.Core/Services/DataParsingService.cs
@@ -26,21 +26,21 @@ namespace ExportViewer.Core.Services
             {
                 var parsingService = new HtmlParsingService();
 
-                return await parsingService.GetMessages(exportFileLocation, locale, exportLocation);
-        }
+                return await parsingService.GetMessages(exportFileLocation , locale , exportLocation);
+            }
             else if (type == ExportType.Json)
             {
                 var parsingService = new JsonParsingService();
 
-                return await parsingService.GetMessages(exportFileLocation, locale, exportLocation);
+                return await parsingService.GetMessages(exportFileLocation , locale , exportLocation);
             }
             return Enumerable.Empty<Message>();
 
         }
 
-        public Task<IEnumerable<string>> GetExportFiles(string exportLocation, ExportType type, IProgress<string> progress)
+        public Task<IEnumerable<string>> GetExportFiles (string exportLocation , ExportType type , IProgress<string> progress)
         {
-            var fileExtensions = new Dictionary<ExportType, string>
+            var fileExtensions = new Dictionary<ExportType , string>
             {
                 { ExportType.HTML, "*.html" },
                 { ExportType.Json, "*.json" }
@@ -48,17 +48,17 @@ namespace ExportViewer.Core.Services
 
             var exportFiles = new List<string>();
 
-            foreach (var subDirectory in new[] { "archived_threads/", "filtered_threads/", "inbox/" })
+            foreach (var subDirectory in new[] { "archived_threads/" , "filtered_threads/" , "inbox/" })
             {
-                var subDirectoryLocation = Path.Combine(exportLocation, "messages/", subDirectory);
+                var subDirectoryLocation = Path.Combine(exportLocation , "messages/" , subDirectory);
                 var fileExtension = fileExtensions[type];
 
                 if (Directory.Exists(subDirectoryLocation))
                 {
                     try
                     {
-                exportFiles.AddRange(Directory.GetFiles(subDirectoryLocation, fileExtension, SearchOption.AllDirectories));
-            }
+                        exportFiles.AddRange(Directory.GetFiles(subDirectoryLocation , fileExtension , SearchOption.AllDirectories));
+                    }
                     catch (Exception ex)
                     {
                         // Handle the exception or log the error
@@ -99,7 +99,7 @@ namespace ExportViewer.Core.Services
         }
 
 
-        public async Task<CultureInfo> GetExportLanguage(string exportLocation, ExportType exportType, IProgress<string> progress)
+        public async Task<CultureInfo> GetExportLanguage (string exportLocation , ExportType exportType , IProgress<string> progress)
         {
             string preferencesLocation;
             string locale;
@@ -108,7 +108,7 @@ namespace ExportViewer.Core.Services
 
             if (exportType == ExportType.HTML)
             {
-                preferencesLocation = Path.Combine(exportLocation, "about_you/preferences.html");
+                preferencesLocation = Path.Combine(exportLocation , "about_you/preferences.html");
                 if (File.Exists(preferencesLocation))
                 {
                     string preferences = await File.ReadAllTextAsync(preferencesLocation);
@@ -117,7 +117,7 @@ namespace ExportViewer.Core.Services
                     if (locale != null)
                     {
                         progress.Report($"Export language: {locale}");
-                        return new CultureInfo(locale, false);
+                        return new CultureInfo(locale , false);
                     }
                 }
                 else
@@ -170,8 +170,8 @@ namespace ExportViewer.Core.Services
             string jsonSearchPattern = "*.json";
             string htmlSearchPattern = "*.html";
 
-            bool hasJsonFiles = Directory.EnumerateFiles(exportLocation, jsonSearchPattern, SearchOption.AllDirectories).Any();
-            bool hasHtmlFiles = Directory.EnumerateFiles(exportLocation, htmlSearchPattern, SearchOption.AllDirectories).Any();
+            bool hasJsonFiles = Directory.EnumerateFiles(exportLocation , jsonSearchPattern , SearchOption.AllDirectories).Any();
+            bool hasHtmlFiles = Directory.EnumerateFiles(exportLocation , htmlSearchPattern , SearchOption.AllDirectories).Any();
 
             if (hasJsonFiles)
             {

--- a/ExportViewer.Core/Services/DataParsingService.cs
+++ b/ExportViewer.Core/Services/DataParsingService.cs
@@ -144,7 +144,7 @@ namespace ExportViewer.Core.Services
             }
             else if (exportType == ExportType.Json)
             {
-                preferencesLocation = Path.Combine(exportLocation, "preferences/language_and_locale.json");
+                preferencesLocation = Path.Combine(exportLocation , "preferences/language_and_locale.json");
                 if (File.Exists(preferencesLocation))
                 {
                     string json = await File.ReadAllTextAsync(preferencesLocation);
@@ -165,7 +165,7 @@ namespace ExportViewer.Core.Services
 
 
 
-        public Task<ExportType> GetExportType(string exportLocation, IProgress<string> progress)
+        public Task<ExportType> GetExportType (string exportLocation , IProgress<string> progress)
         {
             string jsonSearchPattern = "*.json";
             string htmlSearchPattern = "*.html";

--- a/ExportViewer.Core/Services/DataParsingService.cs
+++ b/ExportViewer.Core/Services/DataParsingService.cs
@@ -120,8 +120,12 @@ namespace ExportViewer.Core.Services
                         return new CultureInfo(locale, false);
                     }
                 }
+                else
+                {
+                    return CultureInfo.CurrentCulture;
+                }
 
-                preferencesLocation = Path.Combine(exportLocation, "preferences/language_and_locale.html");
+                preferencesLocation = Path.Combine(exportLocation , "preferences/language_and_locale.html");
                 if (File.Exists(preferencesLocation))
                 {
                     string preferences = await File.ReadAllTextAsync(preferencesLocation);
@@ -130,8 +134,12 @@ namespace ExportViewer.Core.Services
                     if (locale != null)
                     {
                         progress.Report($"Export language: {locale}");
-                        return new CultureInfo(locale, false);
+                        return new CultureInfo(locale , false);
                     }
+                }
+                else
+                {
+                    return CultureInfo.CurrentCulture;
                 }
             }
             else if (exportType == ExportType.Json)

--- a/ExportViewer.Core/Services/DataParsingService.cs
+++ b/ExportViewer.Core/Services/DataParsingService.cs
@@ -71,6 +71,29 @@ namespace ExportViewer.Core.Services
                     Console.WriteLine($"Directory {subDirectoryLocation} does not exist.");
                 }
             }
+            foreach (var subDirectory in new[] { "archived_threads/" , "filtered_threads/" , "inbox/" })
+            {
+                var subDirectoryLocation = Path.Combine(exportLocation , "your_activity_across_facebook" , "messages" , subDirectory);
+                var fileExtension = fileExtensions[type];
+                if (Directory.Exists(subDirectoryLocation))
+                {
+                    try
+                    {
+                        exportFiles.AddRange(Directory.GetFiles(subDirectoryLocation , fileExtensions[type] , SearchOption.AllDirectories));
+                    }
+                    catch (Exception ex)
+                    {
+                        // Handle the exception or log the error
+                        Console.WriteLine($"Error getting files from {subDirectoryLocation}: {ex.Message}");
+                    }
+
+                }
+                else
+                {
+                    // Handle the case when the directory does not exist
+                    Console.WriteLine($"Directory {subDirectoryLocation} does not exist.");
+                }
+            }
 
             return Task.FromResult<IEnumerable<string>>(exportFiles);
         }

--- a/ExportViewer.Core/Services/HtmlParsingService.cs
+++ b/ExportViewer.Core/Services/HtmlParsingService.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
@@ -34,7 +35,7 @@ namespace ExportViewer.Core.Services
                 {
                     if ((node.Descendents().OfType<IHtmlDivElement>().First(x => x.ClassList.Contains("_3-94") && x.ClassList.Contains("_2lem")).TextContent != "") && node.Descendents().OfType<IHtmlAnchorElement>().Any() && (node.Descendents().OfType<IHtmlAnchorElement>().First(x => x.HasAttribute("href"))).GetAttribute("href") != "")
                     {
-                        string href = (node.Descendents().OfType<IHtmlAnchorElement>().First(x => x.HasAttribute("href"))).GetAttribute("href");
+                        string href = node.Descendents().OfType<IHtmlAnchorElement>().First(x => x.HasAttribute("href")).GetAttribute("href");
 
                         if ((!href.StartsWith("http") || !href.StartsWith("https")) && (href.EndsWith(".jpg") || href.EndsWith(".png") || href.EndsWith(".gif") || href.EndsWith(".mp4")))
                         {

--- a/ExportViewer.Core/Services/HtmlParsingService.cs
+++ b/ExportViewer.Core/Services/HtmlParsingService.cs
@@ -52,7 +52,7 @@ namespace ExportViewer.Core.Services
                 });
 
             }
-            else
+            else if (document.QuerySelectorAll("div._3-95._a6-g").Any())
             {
                 divs = document.QuerySelectorAll("div._3-95._a6-g");
 
@@ -89,6 +89,56 @@ namespace ExportViewer.Core.Services
 
                 });
 
+            }
+            else if (document.QuerySelectorAll("div._a6-g").Any())
+            {
+                divs = document.QuerySelectorAll("div._a6-g");
+
+                if (locale.DisplayName == "pl_PL")
+                {
+                    locale.DateTimeFormat.PMDesignator = "po południu";
+                    locale.DateTimeFormat.AMDesignator = "rano";
+                }
+
+                Parallel.ForEach(divs , node =>
+                {
+
+                    var divImage = node.QuerySelector("img._a6_o._3-96");
+                    var divVideo = node.QuerySelector("video._a6_o._3-96");
+                    var divDate = node.QuerySelector("div._3-94._a6-o")?.QuerySelector("div._a72d");
+
+                    if (((divImage != null && divDate != null) || (divVideo != null && divDate != null)) && !string.IsNullOrEmpty(divDate.TextContent))
+                    {
+                        string href = divImage != null ? divImage.GetAttribute("src") : divVideo.GetAttribute("src");
+                        if ((!href.StartsWith("http") || !href.StartsWith("https")) && (href.EndsWith(".jpg") || href.EndsWith(".png") || href.EndsWith(".gif") || href.EndsWith(".mp4")))
+                        {
+                            if (Thread.CurrentThread.CurrentCulture.IsReadOnly || locale.IsReadOnly)
+                            {
+                                var clone = Thread.CurrentThread.CurrentCulture.Clone() as CultureInfo;
+                                clone.DateTimeFormat.PMDesignator = "po południu";
+                                clone.DateTimeFormat.AMDesignator = "rano";
+                                Thread.CurrentThread.CurrentCulture = clone;
+                                Thread.CurrentThread.CurrentUICulture = clone;
+                                locale = clone;
+                            }
+                            else
+                            {
+                                locale.DateTimeFormat.PMDesignator = "po południu";
+                                locale.DateTimeFormat.AMDesignator = "rano";
+                            }
+
+
+
+                            DateTime parsedDate = DateTime.ParseExact(divDate.TextContent , "MMM dd, yyyy h:mm:sstt" , locale);
+
+                            if (File.Exists(exportLocation + href))
+                            {
+                                messages.Add(new Message { Link = href , Date = parsedDate });
+                            }
+                        }
+                    }
+
+                });
             }
 
             return messages.AsEnumerable();


### PR DESCRIPTION
Fixed issue with latest exports not working correctly. Facebook has changed the schema of HTML filed and what is included in them by default and now the cases where it's hard to get the language of export are fixed now as well as the schema for message HTML files has also been updated