### PR TITLE
Fixed issue with media file paths 

### DIFF
--- a/ExportViewer.Core/Services/HtmlParsingService.cs
+++ b/ExportViewer.Core/Services/HtmlParsingService.cs
@@ -43,7 +43,7 @@ namespace ExportViewer.Core.Services
 
                             DateTime date = Convert.ToDateTime(divDate , locale);
 
-                            if (File.Exists(exportLocation + href))
+                            if (File.Exists(Path.Combine(exportLocation, href)))
                             {
                                 messages.Add(new Message { Link = href , Date = date });
                             }
@@ -81,7 +81,7 @@ namespace ExportViewer.Core.Services
 
                             DateTime parsedDate = DateTime.ParseExact(divDate.TextContent , "MMM dd, yyyy h:mm:sstt" , locale);
 
-                            if (File.Exists(exportLocation + href))
+                            if (File.Exists(Path.Combine(exportLocation, href)))
                             {
                                 messages.Add(new Message { Link = href , Date = parsedDate });
                             }
@@ -133,7 +133,7 @@ namespace ExportViewer.Core.Services
 
                                 DateTime parsedDate = DateTime.ParseExact(divDate.TextContent , "MMM dd, yyyy h:mm:sstt" , locale);
 
-                                if (File.Exists(exportLocation + href))
+                                if (File.Exists(Path.Combine(exportLocation, href)))
                                 {
                                     messages.Add(new Message { Link = href , Date = parsedDate });
                                 }
@@ -163,7 +163,7 @@ namespace ExportViewer.Core.Services
 
                                 DateTime parsedDate = DateTime.ParseExact(divDate.TextContent , "MMM dd, yyyy h:mm:sstt" , locale);
 
-                                if (File.Exists(exportLocation + href))
+                                if (File.Exists(Path.Combine(exportLocation, href)))
                                 {
                                     messages.Add(new Message { Link = href , Date = parsedDate });
                                 }


### PR DESCRIPTION
Fixed corner case issue when export path and media file path combined were pointing to a different location due to the lack of one slash in the string